### PR TITLE
- Added the Docker "push" command as a Grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ node_modules
 # IntelliJ
 *.iml
 .idea/
+
+# Eclipse
+.project
+.settings
+

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,0 +1,82 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2014 Johann Troendle
+ *
+ * This file is part of <grunt-dock>.
+ */
+
+var fs = require('fs'), path = require('path'), tar = require('tar-stream'), tarfs = require('tar-fs'), concat = require('concat-stream'), zlib = require('zlib'), async = require('async'), utils = require('./utils');
+
+/**
+ * Push the given image to a registry
+ * 
+ * @param {Object}
+ *          grunt The Grunt Object
+ * @param {Object}
+ *          docker The Dockerode connection
+ * @param {Object}
+ *          options The Grunt options
+ * @param {Function}
+ *          done The done function to call when finished
+ */
+var pushCommand = function(grunt, docker, options, done) {
+  // Pushes an image
+  // NOTE: since it has to change the image name to please Dockerode, the name
+  // of the image is saved in a property and then restored
+  var pushImage = function(imageName, options, auth, callback) {
+
+    var image = docker.getImage(imageName);
+    image.nameBackup = image.name;
+    image.name = options.repo;
+
+    image.push(options, function(err, stream) {
+
+      image.name = image.nameBackup;
+      delete image.nameBackup;
+
+      if (err) {
+        return callback(err);
+      }
+
+      stream.setEncoding("utf8");
+      stream.on("error", callback);
+
+      stream.on("data", function(data) {
+        var jsonData = JSON.parse(data);
+        if (jsonData && jsonData.error) {
+          stream.emit("error", jsonData.error);
+        }
+        jsonData.stream && grunt.log.write(jsonData.stream);
+      });
+
+      stream.on("end", function() {
+        grunt.log.oklns("Push successfuly done.");
+        callback();
+      });
+    }, auth);
+  };
+
+  // Pushes all the images
+  var imageNames = Object.keys(options.images);
+  var auth = options.auth;
+  var nImages = imageNames.length;
+
+  imageNames.forEach(function(imageName) {
+
+    var image = docker.getImage(imageName);
+    pushImage(imageName, options.images[imageName].options.push,
+        options.auth, function(err) {
+
+          if (err) {
+            return done(err);
+          }
+
+          if (--nImages == 0) {
+            done();
+          }
+        });
+  });
+
+};
+
+module.exports = pushCommand;

--- a/tasks/dock.js
+++ b/tasks/dock.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
     list:  require('../lib/list'),
     clean: require('../lib/clean'),
     build: require('../lib/build'),
+    push: require('../lib/push')
   }, require('../lib/container'));
 
   // Process the given command with arg.

--- a/test/push.js
+++ b/test/push.js
@@ -1,0 +1,78 @@
+/*
+ * MIT License (MIT)
+ * Copyright (c) 2014 Johann Troendle
+ *
+ * This file is part of <grunt-dock>.
+ */
+
+var sinon = require('sinon'), expect = require('chai').expect;
+
+var push = require('../lib/push.js');
+
+var nop = function() {
+};
+
+var grunt = {
+  async : nop,
+  log : {
+    ok : nop,
+    writeln : nop,
+    subhead : nop
+  }
+};
+
+var docker = {
+  getImage : nop
+};
+
+var image = {
+  push : nop
+};
+
+describe("push", function() {
+
+  var stubs = {};
+
+  it("should call done() with error", function(done) {
+
+    stubs.push = sinon.stub(image, 'push').yields('error', null);
+    stubs.getImage = sinon.stub(docker, 'getImage').returns({
+      name : 'test',
+      push : stubs.push
+    });
+
+    push(grunt, docker, {
+      images : {
+        'test' : {
+          name : 'test',
+          dockerfile : null,
+          options : {
+            push : {}
+          }
+        }
+      }
+    }, function(e) {
+      expect(e).not.to.be.null;
+      done();
+    });
+  });
+
+  it("should call image.push()", function(done) {
+
+    push(grunt, docker, {
+      images : {
+        'test' : {
+          name : 'test',
+          dockerfile : null,
+          options : {
+            push : {}
+          }
+        }
+      }
+    }, function(e) {
+      expect(image.push.called).to.be.true;
+      done();
+    });
+  });
+
+});


### PR DESCRIPTION
Since it was missing, I added the "push" to grunt-dock: it is rather naive, since I am new to both Docker and Grunt... but it may be better than nothing.

By the way, it requires a few properties to be added to the Gruntfile:

```
    dock : {
      options : {
        auth : {},
        registry : "registry.example.com:5000",
        docker : {
          protocol : "http",
          host : "localhost",
          port : process.env.DOCKER_PORT || 2375
        },
        images : {
          testimage : {
            dockerfile : "test",
            options : {
              push : {
                tag : "0.0.1",
                repo : "registry.example.com:5000/testimage"
              },
            }
          }
        }
      }
```
