### PR TITLE
Adding the error message to display on terminal

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -43,6 +43,7 @@ var buildCommands = function(grunt, docker, options, done, tag) {
       stream.on('data', function(data) {
         var jsonData = JSON.parse(data);
         jsonData.stream && grunt.log.write(jsonData.stream);
+        jsonData.error && grunt.fail.warn(jsonData.error);
       });
 
       stream.on('error', callback);


### PR DESCRIPTION
Adding the error message to display on terminal when BuildImage Docker Remote API sends warning. Currently, there is no message.

**Now**

```
Warning: dist/package.json: no such file or directory Use --force to continue.
```
