### PR TITLE
Check .dockerignore file

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -60,7 +60,7 @@ var buildCommands = function(grunt, docker, options, done, tag) {
         dockerignore = pathentry + '/' +'.dockerignore',
         ignores = [];
 
-    if (fs.statSync(dockerignore)) {
+    if (fs.existsSync(dockerignore) && fs.statSync(dockerignore)) {
       grunt.log.debug('Detected a .dockerignore file, will perform ignoring tests');
       ignores = fs.readFileSync(dockerignore).toString().split("\n");
       ignores.push('.dockerignore');


### PR DESCRIPTION
## Issue:
### Error if the `.dockerignore` file does not exists.

`Warning: ENOENT, no such file or directory '<project root>.dockerignore' Use --force to continue.`
## Fix:

By adding the check of file exists before  `fs.statSync(dockerignore)`
