### PR TITLE
fixed start/stop/restart which did not work for me on mac with docker 1.12

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -48,8 +48,7 @@ commands.start = function(grunt, docker, options, done, tag) {
 
             for (var c = 0; c < containers.length; c++) {
               if (containers[c].Image.indexOf(utils.qualifiedImageName(tag,
-                  options.registry, null)
-                  + ':') === 0) {
+                  options.registry, null)) === 0) {
                 // If the current container is running or terminated
                 if (utils.getContainerStatus(containers[c]) === "RUNNING"
                     || utils.getContainerStatus(containers[c]) === "STOPPED") {
@@ -176,7 +175,8 @@ var actioning = {
           var container = null;
 
           for (var c = 0; c < containers.length; c++) {
-            if (containers[c].Image.indexOf(tag + ':') === 0) {
+            if (containers[c].Image.indexOf(utils.qualifiedImageName(tag,
+                  options.registry, null)) === 0) {
               container = containers[c];
               break;
             }


### PR DESCRIPTION
start/stop/restart/logs actions did not work for me on mac with the boot2docker version 1.12.
I changed 2 lines of code which made it work for me. Please review if you want to pull the changes.
