### PR TITLE
Handle JSON parse error on multiple build stream data chunks

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -34,6 +34,8 @@ var buildCommands = function(grunt, docker, options, done, tag) {
 
     docker.buildImage(data, options, function(err, stream) {
 
+      var cumulativeData = '';
+
       if (err) {
         return callback(err);
       }
@@ -41,13 +43,22 @@ var buildCommands = function(grunt, docker, options, done, tag) {
       stream.setEncoding('utf8');
 
       stream.on('data', function(data) {
-        var jsonData = JSON.parse(data);
-        jsonData.stream && grunt.log.write(jsonData.stream);
-        jsonData.error && grunt.fail.warn(jsonData.error);
+          cumulativeData += data;
+          try {
+            var jsonData = JSON.parse(cumulativeData);
+            jsonData.stream && grunt.log.write(jsonData.stream);
+            jsonData.error && grunt.fail.warn(jsonData.error);
+            cumulativeData = '';
+          } catch(err) {
+          }
       });
 
-      stream.on('error', callback);
+      stream.on('error', function() {
+        cumulativeData = '';
+        callback();
+      });
       stream.on('end', function() {
+        cumulativeData = '';
         grunt.log.oklns('Build successfuly done.');
         callback();
       });
@@ -74,7 +85,7 @@ var buildCommands = function(grunt, docker, options, done, tag) {
         if (ignore) {
           grunt.log.debug('Ignoring file [' + relativeName +']');
         }
-        
+
         return ignore;
       }
     }).pipe(zlib.createGzip())


### PR DESCRIPTION
Where the streamed data to `docker.buildImage` is large (for instance in a large app with 100+ modules), a single message can be split among multiple chunks, in which case `JSON.parse(data)` will throw an error and the build will fail out. 

This change temporarily adds the contents of `data` into a variable `cumulativeData`. If `JSON.parse(cumulativeData)` fails, it will just go on to the next chunk, add it to `cumulativeData` and try again. If it succeeds, it will send the parsed data to the log and clear `cumulativeData` until the next chunk.

Also, just to be sure nothing hangs around, `cumulativeData` is cleared on both `error` and `end` states of the stream.